### PR TITLE
Allow custom MCP server metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ In read-only mode, only [readonly SQL operations](https://github.com/bytebase/db
 
 This provides an additional layer of security when connecting to production databases.
 
+### Custom Server Identity
+
+DBHub exposes its identity to MCP clients. If you run multiple instances,
+set a unique ID, name, or description using environment variables or CLI options:
+
+```bash
+MCP_ID="redpanda" MCP_NAME="Redpanda DB" npx @bytebase/dbhub --dsn "..."
+# or
+npx @bytebase/dbhub --mcp-id redpanda --mcp-name "Redpanda DB" --dsn "..."
+```
+
 ### Configure your database connection
 
 You can use DBHub in demo mode with a sample employee database for testing:
@@ -315,6 +326,9 @@ Extra query parameters:
 | transport | Transport mode: `stdio` or `sse`                                | `stdio`                      |
 | port      | HTTP server port (only applicable when using `--transport=sse`) | `8080`                       |
 | readonly  | Restrict SQL execution to read-only operations                  | `false`                      |
+| mcp-id    | Unique server identifier                                        | `dbhub`                      |
+| mcp-name  | Human-friendly server name                                      | `DBHub`                      |
+| mcp-description | Server description                                        | `Universal DB Gateway`       |
 
 The demo mode uses an in-memory SQLite database loaded with the [sample employee database](https://github.com/bytebase/dbhub/tree/main/resources/employee-sqlite) that includes tables for employees, departments, titles, salaries, department employees, and department managers. The sample database includes SQL scripts for table creation, data loading, and testing.
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -212,3 +212,25 @@ export function redactDSN(dsn: string): string {
     return dsn.replace(/\/\/([^:]+):([^@]+)@/, "//$1:***@");
   }
 }
+
+export interface ServerMetadata {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * Resolve server metadata (id, name, description) from CLI args or env vars
+ */
+export function resolveServerMetadata(): ServerMetadata {
+  const args = parseCommandLineArgs();
+
+  const id = args["mcp-id"] || process.env.MCP_ID || "dbhub";
+  const name = args["mcp-name"] || process.env.MCP_NAME || "DBHub";
+  const description =
+    args["mcp-description"] ||
+    process.env.MCP_DESCRIPTION ||
+    "Universal DB Gateway";
+
+  return { id, name, description };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "url";
 
 import { ConnectorManager } from "./connectors/manager.js";
 import { ConnectorRegistry } from "./connectors/interface.js";
-import { resolveDSN, resolveTransport, resolvePort, isDemoMode, redactDSN, isReadOnlyMode } from "./config/env.js";
+import { resolveDSN, resolveTransport, resolvePort, isDemoMode, redactDSN, isReadOnlyMode, resolveServerMetadata } from "./config/env.js";
 import { getSqliteInMemorySetupSql } from "./config/demo-loader.js";
 import { registerResources } from "./resources/index.js";
 import { registerTools } from "./tools/index.js";
@@ -76,9 +76,12 @@ See documentation for more details on configuring database connections.
       process.exit(1);
     }
 
-    // Create MCP server
+    // Create MCP server with customizable metadata
+    const { id, name, description } = resolveServerMetadata();
     const server = new McpServer({
-      name: SERVER_NAME,
+      id,
+      name,
+      description,
       version: SERVER_VERSION,
     });
 


### PR DESCRIPTION
## Summary
- let DBHub instances expose unique MCP identity
- add helper to resolve metadata from env vars
- document the new options in README

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f13e63ab4832c9a8c478bd3299578